### PR TITLE
refactor: consolidate pyinstaller options

### DIFF
--- a/code/build_exe.bat
+++ b/code/build_exe.bat
@@ -31,20 +31,10 @@ python --version
 echo [i] Building (onedir first, it's more reliable)...
 set LOG=build_log.txt
 del /q "%LOG%" 2>nul
+set "PYI_BASE=pyinstaller \"%MAIN%\" --name \"%NAME%\" --noconfirm --clean --log-level DEBUG --noconsole"
+set "PYI_TK=--collect-submodules tkinter --collect-submodules tkinter.ttk --collect-submodules tkinter.filedialog --collect-submodules tkinter.messagebox"
 
-pyinstaller ^
-  "%MAIN%" ^
-  --name "%NAME%" ^
-  --onedir ^
-  --noconfirm ^
-  --clean ^
-  --log-level DEBUG ^
-  --noconsole ^
-  --collect-submodules tkinter ^
-  --collect-submodules tkinter.ttk ^
-  --collect-submodules tkinter.filedialog ^
-  --collect-submodules tkinter.messagebox ^
-  > "%LOG%" 2>&1
+%PYI_BASE% %PYI_TK% --onedir > "%LOG%" 2>&1
 
 if errorlevel 1 (
   echo [!] Build failed. See %LOG%
@@ -55,19 +45,7 @@ if errorlevel 1 (
 echo [i] Build OK. Check dist\%NAME%\
 
 echo [i] Now building onefile (if needed)...
-pyinstaller ^
-  "%MAIN%" ^
-  --name "%NAME%" ^
-  --onefile ^
-  --noconfirm ^
-  --clean ^
-  --log-level DEBUG ^
-  --noconsole ^
-  --collect-submodules tkinter ^
-  --collect-submodules tkinter.ttk ^
-  --collect-submodules tkinter.filedialog ^
-  --collect-submodules tkinter.messagebox ^
-  >> "%LOG%" 2>&1
+%PYI_BASE% %PYI_TK% --onefile >> "%LOG%" 2>&1
 
 if errorlevel 1 (
   echo [!] Onefile failed. OneDir is ready to use. See %LOG%


### PR DESCRIPTION
## Summary
- centralize repeated PyInstaller arguments into reusable variables
- reuse shared command for onedir and onefile builds

## Testing
- `python -m py_compile mrq_launcher.py`
- `pytest` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa842b7704832b94a0bbffb8073488