### PR TITLE
Fix skip_next queue fail policy and retry behavior

### DIFF
--- a/code/mrq_launcher.py
+++ b/code/mrq_launcher.py
@@ -17,7 +17,7 @@ from tkinter import ttk
 # -------------------------------------------------
 # App meta
 # -------------------------------------------------
-APP_VERSION = "1.4.1"
+APP_VERSION = "1.4.2"
 # -------------------------------------------------
 # Helpers
 # -------------------------------------------------
@@ -880,6 +880,7 @@ class MRQLauncher(tk.Tk):
         def worker():
             self.worker_running = True
             idx = 0
+            skip_next_pending = 0
             while True:
                 if self.stop_all and self.runtime_q.empty():
                     break
@@ -893,14 +894,21 @@ class MRQLauncher(tk.Tk):
                 if not all([t.uproject, t.level, t.sequence, t.preset]):
                     self._log(f"[{idx}] Skipped: task is incomplete")
                     continue
-
-                attempt = 0
-                logfile = self._task_logfile(t)
                 gi = None
                 try:
                     gi = self.settings.tasks.index(t)
                 except ValueError:
                     gi = None
+
+                if skip_next_pending > 0:
+                    skip_next_pending -= 1
+                    if gi is not None:
+                        self._set_status_async(gi, "Skipped (policy)")
+                    self._log(f"[{idx}] Skipped by fail policy (skip_next)")
+                    continue
+
+                attempt = 0
+                logfile = self._task_logfile(t)
 
                 while attempt <= retries and not self.stop_all:
                     attempt += 1
@@ -1041,7 +1049,10 @@ class MRQLauncher(tk.Tk):
                             if gi is not None:
                                 self._set_status_async(gi, f"Failed (rc={rc})")
                             self._log(f"[{idx}] Failed after {retries+1} attempt(s)")
-                        if policy == "skip_next":
+                            if policy == "skip_next":
+                                skip_next_pending = 1
+                                self._log(f"[{idx}] Policy skip_next: next task will be skipped")
+                        if attempt > retries:
                             break
 
                 if self.stop_all:


### PR DESCRIPTION
### Motivation
- Ensure the `skip_next` fail policy actually skips the following queued task after a task ultimately fails. 
- Preserve retry semantics so configured retries are attempted before any `skip_next` effect is applied. 
- Improve queue visibility by marking policy-skipped tasks in the UI and update the app version.

### Description
- Introduced a `skip_next_pending` counter in the queue worker to record when the next task should be skipped. 
- Compute the global task index (`gi`) earlier and apply the pending skip before starting retries, setting the task status to `Skipped (policy)` and logging the event. 
- Schedule the skip only after a task has exhausted all retries (set `skip_next_pending = 1` and log the policy action). 
- Bumped `APP_VERSION` from `1.4.1` to `1.4.2` and added concise logging for skipped tasks.

### Testing
- Compiled the modified file with `python -m py_compile code/mrq_launcher.py`, which succeeded. 
- Verified the source changes were committed (commit message: "Fix skip_next fail policy handling in queue worker").

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef6c06f7b0832bb0b7c446b03f5d96)