### PR TITLE
Implement CLI-6: use identity-based task lookup to fix status updates for duplicated tasks

### DIFF
--- a/code/mrq_launcher.py
+++ b/code/mrq_launcher.py
@@ -17,7 +17,7 @@ from tkinter import ttk
 # -------------------------------------------------
 # App meta
 # -------------------------------------------------
-APP_VERSION = "1.4.2"
+APP_VERSION = "1.4.3"
 # -------------------------------------------------
 # Helpers
 # -------------------------------------------------
@@ -420,6 +420,16 @@ class MRQLauncher(tk.Tk):
         self.log.pack(fill=tk.BOTH, expand=True)
 
         self.refresh_tree()
+
+    def _find_task_index_by_identity(self, task: RenderTask) -> Optional[int]:
+        """
+        Locate a task by object identity, not dataclass value equality.
+        This keeps duplicate tasks (same values) addressable as distinct rows.
+        """
+        for i, existing in enumerate(self.settings.tasks):
+            if existing is task:
+                return i
+        return None
 
     def _on_tree_right_click(self, event):
         """Select row under cursor and show the task context menu."""
@@ -894,11 +904,7 @@ class MRQLauncher(tk.Tk):
                 if not all([t.uproject, t.level, t.sequence, t.preset]):
                     self._log(f"[{idx}] Skipped: task is incomplete")
                     continue
-                gi = None
-                try:
-                    gi = self.settings.tasks.index(t)
-                except ValueError:
-                    gi = None
+                gi = self._find_task_index_by_identity(t)
 
                 if skip_next_pending > 0:
                     skip_next_pending -= 1
@@ -1102,11 +1108,9 @@ class MRQLauncher(tk.Tk):
                 continue
             self.runtime_q.put(t)
             if mark_queued:
-                try:
-                    gi = self.settings.tasks.index(t)
+                gi = self._find_task_index_by_identity(t)
+                if gi is not None:
                     self._set_status_async(gi, "Queued")
-                except ValueError:
-                    pass
             count += 1
         if count:
             self._log(f"{log_prefix}{count} task(s) to queue")


### PR DESCRIPTION
### Motivation
- Duplicate tasks created by value-copy (dataclass) were indistinguishable via `list.index(task)`, causing status updates to be applied to the first equal task row instead of the intended one.

### Description
- Bumped app version to `1.4.3` in `code/mrq_launcher.py`.
- Added `_find_task_index_by_identity(task: RenderTask)` to locate tasks by object identity (`is`) rather than dataclass equality.
- Replaced `list.index(task)` usages in the queue worker and `_enqueue_tasks` with the new identity-based lookup so `Queued`, `Rendering`, `Done` and `Failed` statuses map to the correct duplicated row.
- Kept behavior unchanged for other flows while ensuring correct UI status updates for duplicated tasks.

### Testing
- Ran `python -m py_compile code/mrq_launcher.py`, which succeeded without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef71da37c0832bb9fc7c91a2c94201)