### PR TITLE
Implement CLI-10: fix multi-select duplicate index shifting

### DIFF
--- a/code/mrq_launcher.py
+++ b/code/mrq_launcher.py
@@ -17,7 +17,7 @@ from tkinter import ttk
 # -------------------------------------------------
 # App meta
 # -------------------------------------------------
-APP_VERSION = "1.4.3"
+APP_VERSION = "1.4.4"
 # -------------------------------------------------
 # Helpers
 # -------------------------------------------------
@@ -534,7 +534,9 @@ class MRQLauncher(tk.Tk):
         sel = self._selected_indices()
         if not sel:
             return
-        for idx in sel:
+        # Iterate from bottom to top so index shifts do not affect
+        # which original rows are duplicated.
+        for idx in sorted(sel, reverse=True):
             src = self.settings.tasks[idx]
             self.settings.tasks.insert(idx + 1, RenderTask(**asdict(src)))
             self.state.insert(idx + 1, {"status": "—", "progress": None, "start": None, "end": None})


### PR DESCRIPTION
### Motivation
- Duplicating multiple selected tasks could copy the wrong source rows because inserting new items shifts later indices, so the duplication behavior must be made stable for multi-selection.

### Description
- Update `duplicate_task` to iterate selected indices in descending order using `for idx in sorted(sel, reverse=True):` and add an explanatory comment to prevent index-shift issues; also bump `APP_VERSION` to `1.4.4`.

### Testing
- Ran `python -m py_compile code/mrq_launcher.py`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef7a1e47fc832bb3eaa946f72e7109)