### PR TITLE
Implement CLI-12: purge removed/unchecked tasks from runtime queue

### DIFF
--- a/code/mrq_launcher.py
+++ b/code/mrq_launcher.py
@@ -558,6 +558,7 @@ class MRQLauncher(tk.Tk):
     def remove_unchecked_tasks(self):
         """Remove all tasks that are not checked (enabled == False)."""
         removed = 0
+        removed_tasks = []
         new_tasks = []
         new_state = []
         for i, t in enumerate(self.settings.tasks):
@@ -566,7 +567,11 @@ class MRQLauncher(tk.Tk):
                 if i < len(self.state):
                     new_state.append(self.state[i])
             else:
+                removed_tasks.append(t)
                 removed += 1
+        # Also purge queued runtime entries for tasks that are being removed.
+        # Otherwise disabled+removed tasks can still render later from runtime_q.
+        self._remove_tasks_from_runtime_queue(removed_tasks)
         self.settings.tasks = new_tasks
         self.state = new_state
         self.refresh_tree()


### PR DESCRIPTION
### Motivation
- Prevent tasks that were previously enqueued from being rendered after they are removed or cleared as unchecked by ensuring queued entries are purged when the tasks are deleted.

### Description
- In `remove_unchecked_tasks` collect task objects being removed into `removed_tasks` and call `_remove_tasks_from_runtime_queue(removed_tasks)` before updating `settings.tasks` and the UI.
- This reuses the existing `_remove_tasks_from_runtime_queue` helper (already invoked from `remove_task`) to remove queued entries by identity from `runtime_q` so deleted/disabled tasks cannot run later.
- No external API changes; behavior is limited to internal queue housekeeping and UI state consistency.

### Testing
- Ran `python -m py_compile code/mrq_launcher.py` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef82966f2c832bb2b7ff7ec691605e)