### PR TITLE
Implement CLI-13: drop disabled tasks from runtime queue

### DIFF
--- a/code/mrq_launcher.py
+++ b/code/mrq_launcher.py
@@ -17,7 +17,7 @@ from tkinter import ttk
 # -------------------------------------------------
 # App meta
 # -------------------------------------------------
-APP_VERSION = "1.4.4"
+APP_VERSION = "1.4.5"
 # -------------------------------------------------
 # Helpers
 # -------------------------------------------------
@@ -580,14 +580,25 @@ class MRQLauncher(tk.Tk):
     def set_enabled_all(self, val: bool):
         for t in self.settings.tasks:
             t.enabled = val
+        # If tasks are being disabled, also remove their pending queued copies.
+        # Otherwise already-enqueued items can still run despite being unchecked.
+        if not val:
+            self._remove_tasks_from_runtime_queue(self.settings.tasks)
         self.refresh_tree()
 
     def toggle_selected(self):
         sel = self._selected_indices()
         if not sel:
             return
+        disabled_now = []
         for idx in sel:
-            self.settings.tasks[idx].enabled = not self.settings.tasks[idx].enabled
+            t = self.settings.tasks[idx]
+            t.enabled = not t.enabled
+            if not t.enabled:
+                disabled_now.append(t)
+        if disabled_now:
+            # Keep runtime queue aligned with the visible enabled state.
+            self._remove_tasks_from_runtime_queue(disabled_now)
         self.refresh_tree()
 
     # Save/Load JSON (queue)


### PR DESCRIPTION
### Motivation
- Prevent tasks that were disabled in the UI from still running due to pre-existing entries in the runtime queue.

### Description
- Bumped app version from `1.4.4` to `1.4.5` in `code/mrq_launcher.py`.
- When `set_enabled_all(False)` is used, pending queued copies of the tasks are removed via `_remove_tasks_from_runtime_queue` so disabled tasks cannot run from stale queue entries.
- `toggle_selected()` now collects tasks toggled off and removes their queued copies from `runtime_q` to keep the runtime queue aligned with visible enabled state.
- Changes are limited to `code/mrq_launcher.py` and reuse the existing `_remove_tasks_from_runtime_queue` helper for queue purging.

### Testing
- Ran `python -m py_compile code/mrq_launcher.py` and the file compiled successfully with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef83391428832b85c1b6a081955871)